### PR TITLE
Deferred task system fix

### DIFF
--- a/PolyEngine/Engine/Src/DeferredTaskSystem.hpp
+++ b/PolyEngine/Engine/Src/DeferredTaskSystem.hpp
@@ -63,7 +63,8 @@ namespace Poly
 		/// <param name="world">Pointer to world.</summary>
 		template<typename T, typename ...Args> T* AddWorldComponentImmediate(World* w, Args && ...args)
 		{
-			return w->AddWorldComponent<T>(std::forward<Args>(args)...);
+			w->AddWorldComponent<T>(std::forward<Args>(args)...);
+			return w->GetWorldComponent<T>();
 		}
 
 		/// <summary>Removes world component from world.</summary>

--- a/PolyEngine/Engine/Src/DeferredTaskSystem.hpp
+++ b/PolyEngine/Engine/Src/DeferredTaskSystem.hpp
@@ -49,20 +49,21 @@ namespace Poly
 		/// <summary>Adds component to entity immediately.</summary>
 		/// <param name="world">Pointer to world entity is in.</summary>
 		/// <param name="entityId">ID of the entity.</summary>
-		template<typename T, typename ...Args> void AddComponentImmediate(World* w, const UniqueID & entityId, Args && ...args)
+		template<typename T, typename ...Args> T* AddComponentImmediate(World* w, const UniqueID & entityId, Args && ...args)
 		{
 			w->AddComponent<T>(entityId, std::forward<Args>(args)...);
 			DeferredTaskWorldComponent* cmp = w->GetWorldComponent<DeferredTaskWorldComponent>();
 			T* newCmp = w->GetComponent<T>(entityId);
 			cmp->NewlyCreatedComponents.PushBack(newCmp);
 			newCmp->SetFlags(eComponentBaseFlags::NEWLY_CREATED);
+			return newCmp;
 		}
 
 		/// <summary>Adds world component to world.</summary>
 		/// <param name="world">Pointer to world.</summary>
-		template<typename T, typename ...Args> void AddWorldComponentImmediate(World* w, Args && ...args)
+		template<typename T, typename ...Args> T* AddWorldComponentImmediate(World* w, Args && ...args)
 		{
-			w->AddWorldComponent<T>(std::forward<Args>(args)...);
+			return w->AddWorldComponent<T>(std::forward<Args>(args)...);
 		}
 
 		/// <summary>Removes world component from world.</summary>

--- a/PolyEngine/Engine/Src/DeferredTaskWorldComponent.hpp
+++ b/PolyEngine/Engine/Src/DeferredTaskWorldComponent.hpp
@@ -10,13 +10,13 @@ namespace Poly
 	namespace DeferredTaskSystem
 	{
 		void DeferredTaskPhase(World* w);
-		template<typename T, typename ...Args> void AddComponentImmediate(World* w, const UniqueID & entityId, Args && ...args);
+		template<typename T, typename ...Args> T* AddComponentImmediate(World* w, const UniqueID & entityId, Args && ...args);
 	}
 
 	class ENGINE_DLLEXPORT DeferredTaskWorldComponent : public ComponentBase
 	{
 		friend void DeferredTaskSystem::DeferredTaskPhase(World*);
-		template<typename T, typename ...Args> friend void DeferredTaskSystem::AddComponentImmediate(World* w, const UniqueID & entityId, Args && ...args);
+		template<typename T, typename ...Args> friend T* DeferredTaskSystem::AddComponentImmediate(World* w, const UniqueID & entityId, Args && ...args);
 	public:
 		DeferredTaskWorldComponent() = default;
 

--- a/PolyEngine/Engine/Src/World.hpp
+++ b/PolyEngine/Engine/Src/World.hpp
@@ -14,8 +14,8 @@ namespace Poly {
 	{
 		UniqueID ENGINE_DLLEXPORT SpawnEntityImmediate(World* w);
 		void ENGINE_DLLEXPORT DestroyEntityImmediate(World* w, const UniqueID& entityId);
-		template<typename T, typename ...Args> void AddComponentImmediate(World* w, const UniqueID & entityId, Args && ...args);
-		template<typename T, typename ...Args> void AddWorldComponentImmediate(World* w, Args && ...args);
+		template<typename T, typename ...Args> T* AddComponentImmediate(World* w, const UniqueID & entityId, Args && ...args);
+		template<typename T, typename ...Args> T* AddWorldComponentImmediate(World* w, Args && ...args);
 		template<typename T> void RemoveWorldComponentImmediate(World* w);
 	}
 	struct InputState;
@@ -159,8 +159,8 @@ namespace Poly {
 
 		friend UniqueID DeferredTaskSystem::SpawnEntityImmediate(World*);
 		friend void DeferredTaskSystem::DestroyEntityImmediate(World* w, const UniqueID& entityId);
-		template<typename T, typename ...Args> friend void DeferredTaskSystem::AddComponentImmediate(World* w, const UniqueID & entityId, Args && ...args);
-		template<typename T, typename ...Args> friend void DeferredTaskSystem::AddWorldComponentImmediate(World* w, Args && ...args);
+		template<typename T, typename ...Args> friend T* DeferredTaskSystem::AddComponentImmediate(World* w, const UniqueID & entityId, Args && ...args);
+		template<typename T, typename ...Args> friend T* DeferredTaskSystem::AddWorldComponentImmediate(World* w, Args && ...args);
 		template<typename T> friend void DeferredTaskSystem::RemoveWorldComponentImmediate(World* w);
 
 		//------------------------------------------------------------------------------
@@ -214,11 +214,12 @@ namespace Poly {
 
 		//------------------------------------------------------------------------------
 		template<typename T, typename... Args>
-		void AddWorldComponent(Args&&... args)
+		T* AddWorldComponent(Args&&... args)
 		{
 			const auto ctypeID = GetWorldComponentID<T>();
 			HEAVY_ASSERTE(!HasWorldComponent(ctypeID), "Failed at AddWorldComponent() - a world component of a given type already exists!");
 			WorldComponents[ctypeID] = new T(std::forward<Args>(args)...);
+			return static_cast<T*>(WorldComponents[ctypeID]);
 		}
 
 		//------------------------------------------------------------------------------

--- a/PolyEngine/Engine/Src/World.hpp
+++ b/PolyEngine/Engine/Src/World.hpp
@@ -214,12 +214,11 @@ namespace Poly {
 
 		//------------------------------------------------------------------------------
 		template<typename T, typename... Args>
-		T* AddWorldComponent(Args&&... args)
+		void AddWorldComponent(Args&&... args)
 		{
 			const auto ctypeID = GetWorldComponentID<T>();
 			HEAVY_ASSERTE(!HasWorldComponent(ctypeID), "Failed at AddWorldComponent() - a world component of a given type already exists!");
 			WorldComponents[ctypeID] = new T(std::forward<Args>(args)...);
-			return static_cast<T*>(WorldComponents[ctypeID]);
 		}
 
 		//------------------------------------------------------------------------------


### PR DESCRIPTION
 DeferredTaskSystem::AddComponentImmediate  now returns component so You don't have to 
World::GetComponent just after immediate addition of that component.