### PR TITLE
Small fixes to compile project with clang 8.0

### DIFF
--- a/PolyEngine/Core/Src/Utils/Optional.hpp
+++ b/PolyEngine/Core/Src/Utils/Optional.hpp
@@ -60,8 +60,8 @@ namespace Poly {
 				return ret;
 			}
 
-			V ValueOr(V&& fallback) const &  { if (HasValue()) { return Value(); } return fallback; } //todo(vuko): do not copy when possible
-			V ValueOr(V&& fallback) const && { if (HasValue()) { return std::move(Value()); } return fallback; }
+			V ValueOr(V&& fallback) const &  { if (HasValue()) { return Value(); } return std::move(fallback); }
+			V ValueOr(V&& fallback) const && { if (HasValue()) { return std::move(Value()); } return std::move(fallback); }
 
 		protected:
 			bool initialized;

--- a/PolyEngine/Editor/Src/Widgets/Inspectors/WorldInspectorWidget.cpp
+++ b/PolyEngine/Editor/Src/Widgets/Inspectors/WorldInspectorWidget.cpp
@@ -154,7 +154,7 @@ void WorldInspectorWidget::EntitiesSelectionChanged()
 		for (auto i : ItemToEntity)
 			if (i.second == e)
 			{
-				Tree->setItemSelected(i.first, true);
+				i.first->setSelected(true);
 				break;
 			}
 

--- a/PolyEngine/UnitTests/Src/MatrixTests.cpp
+++ b/PolyEngine/UnitTests/Src/MatrixTests.cpp
@@ -118,7 +118,6 @@ TEST_CASE("Matrx-Vector multiplication operator", "[Matrix]") {
   Matrix m2(data2);
   Matrix m3(data3);
   Vector v1(1,2,3);
-  Vector v2(4,6,5);
 
   REQUIRE(m1*v1 == Vector(1,3,-2));
   REQUIRE(m2*v1 == Vector(4,5,6));

--- a/PolyEngine/UnitTests/Src/OptionalTests.cpp
+++ b/PolyEngine/UnitTests/Src/OptionalTests.cpp
@@ -133,8 +133,8 @@ TEST_CASE("Optional with non-default-constructible", "[Optional]") {
 			REQUIRE(some.ValueOr(Counting(16)) == Counting(8));
 		}
 		REQUIRE(gCurrentInstances == 0);
-		REQUIRE(gCopiesEver == 2); //todo(vuko): implementation of ValueOr() was based on the official C++17 optional; can we do better?
-		REQUIRE(gMovesEver  == 1); //one into the optional
+		REQUIRE(gCopiesEver == 1);
+		REQUIRE(gMovesEver  == 2);
 	}
 
 	SECTION("Move constructor") {


### PR DESCRIPTION
 - fixed optional returning by copy instead by move
 - removed unused variable in unit test
 - replaced deprecated in WorldInspectorWidget