### PR TITLE
Replace insert usage with emplace for std::map

### DIFF
--- a/PolyEngine/Engine/Src/AI/PathfindingSystem.cpp
+++ b/PolyEngine/Engine/Src/AI/PathfindingSystem.cpp
@@ -41,7 +41,7 @@ std::optional<std::vector<::pe::core::math::Vector>> CalculateNewPath(const NavG
 
 	AllNodes.push_back(PathNode(startNode, 0, graph->GetHeuristicCost(startNode, destNode) ));
 	openList.Push(std::make_pair(AllNodes.size() - 1, graph->GetHeuristicCost(startNode, destNode)));
-	minCosts.insert({startNode, 0.f});
+	minCosts.emplace(std::make_pair(startNode, 0.f));
 
 	i64 bestNodeIdx = -1;
 	std::vector<const NavNode*> connections(8);

--- a/PolyEngine/Engine/Src/AI/PathfindingSystem.cpp
+++ b/PolyEngine/Engine/Src/AI/PathfindingSystem.cpp
@@ -41,7 +41,7 @@ std::optional<std::vector<::pe::core::math::Vector>> CalculateNewPath(const NavG
 
 	AllNodes.push_back(PathNode(startNode, 0, graph->GetHeuristicCost(startNode, destNode) ));
 	openList.Push(std::make_pair(AllNodes.size() - 1, graph->GetHeuristicCost(startNode, destNode)));
-	minCosts.emplace(std::make_pair(startNode, 0.f));
+	minCosts.emplace(startNode, 0.f);
 
 	i64 bestNodeIdx = -1;
 	std::vector<const NavNode*> connections(8);

--- a/PolyEngine/Engine/Src/ECS/ComponentIDGenerator.hpp
+++ b/PolyEngine/Engine/Src/ECS/ComponentIDGenerator.hpp
@@ -85,14 +85,14 @@ namespace Poly
 		{
 			size_t id = ::Poly::GetComponentID<T>();
 			RTTI::TypeInfo typeinfo = RTTI::TypeInfo::Get<T>();
-			TypeToIDMap.insert({ typeinfo, id });
-			IDToTypeMap.insert({ id, typeinfo});
+			TypeToIDMap.emplace(std::make_pair( typeinfo, id ));
+			IDToTypeMap.emplace(std::make_pair( id, typeinfo ));
 			std::function<::pe::core::memory::IterablePoolAllocatorBase*(size_t)> allocator = [](size_t count)
 			{
 				return static_cast<::pe::core::memory::IterablePoolAllocatorBase*>(
 					new ::pe::core::memory::IterablePoolAllocator<T>(count));
 			};
-			IDToCreatorMap.insert({ id, allocator });
+			IDToCreatorMap.emplace(std::make_pair( id, allocator ));
 		}
 
 		std::optional<size_t> GetComponentID(const RTTI::TypeInfo& typeinfo) const;

--- a/PolyEngine/Engine/Src/ECS/ComponentIDGenerator.hpp
+++ b/PolyEngine/Engine/Src/ECS/ComponentIDGenerator.hpp
@@ -85,14 +85,14 @@ namespace Poly
 		{
 			size_t id = ::Poly::GetComponentID<T>();
 			RTTI::TypeInfo typeinfo = RTTI::TypeInfo::Get<T>();
-			TypeToIDMap.emplace(std::make_pair( typeinfo, id ));
-			IDToTypeMap.emplace(std::make_pair( id, typeinfo ));
+			TypeToIDMap.emplace( typeinfo, id );
+			IDToTypeMap.emplace( id, typeinfo );
 			std::function<::pe::core::memory::IterablePoolAllocatorBase*(size_t)> allocator = [](size_t count)
 			{
 				return static_cast<::pe::core::memory::IterablePoolAllocatorBase*>(
 					new ::pe::core::memory::IterablePoolAllocator<T>(count));
 			};
-			IDToCreatorMap.emplace(std::make_pair( id, allocator ));
+			IDToCreatorMap.emplace( id, allocator );
 		}
 
 		std::optional<size_t> GetComponentID(const RTTI::TypeInfo& typeinfo) const;

--- a/PolyEngine/Engine/Src/Resources/MeshResource.cpp
+++ b/PolyEngine/Engine/Src/Resources/MeshResource.cpp
@@ -46,7 +46,7 @@ MeshResource::MeshResource(const core::storage::String& path)
 	for (size_t i = 0; i < scene->mNumAnimations; ++i)
 	{
 		Animation* a = new Animation(scene->mAnimations[i]);
-		Animations.insert({ a->Name, a });
+		Animations.emplace(std::make_pair( a->Name, a ));
 	}
 
 	AxisAlignedBoundingBox = core::math::AABox(min, max - min);
@@ -90,7 +90,7 @@ void Poly::MeshResource::LoadBones(aiNode* node)
 	{
 		for (const MeshResource::SubMesh::Bone& bone : subMesh->GetBones())
 		{
-			boneNameToIdx.insert({ bone.name , Bones.size()});
+			boneNameToIdx.emplace(std::make_pair( bone.name , Bones.size()));
 			Bone b(bone.name);
 			b.boneFromModel = bone.boneFromModel;
 			Bones.push_back(b);
@@ -333,7 +333,7 @@ Poly::MeshResource::Animation::Animation(aiAnimation * anim)
 			c.Scales.push_back({ vector, (float)anim->mChannels[i]->mScalingKeys[j].mTime });
 		}
 		core::storage::String nameCpy = c.Name;
-		channels.insert({ nameCpy, std::move(c) });
+		channels.emplace(std::make_pair( nameCpy, std::move(c) ));
 	}
 }
 

--- a/PolyEngine/Engine/Src/Resources/MeshResource.cpp
+++ b/PolyEngine/Engine/Src/Resources/MeshResource.cpp
@@ -46,7 +46,7 @@ MeshResource::MeshResource(const core::storage::String& path)
 	for (size_t i = 0; i < scene->mNumAnimations; ++i)
 	{
 		Animation* a = new Animation(scene->mAnimations[i]);
-		Animations.emplace(std::make_pair( a->Name, a ));
+		Animations.emplace( a->Name, a );
 	}
 
 	AxisAlignedBoundingBox = core::math::AABox(min, max - min);
@@ -90,7 +90,7 @@ void Poly::MeshResource::LoadBones(aiNode* node)
 	{
 		for (const MeshResource::SubMesh::Bone& bone : subMesh->GetBones())
 		{
-			boneNameToIdx.emplace(std::make_pair( bone.name , Bones.size()));
+			boneNameToIdx.emplace( bone.name , Bones.size());
 			Bone b(bone.name);
 			b.boneFromModel = bone.boneFromModel;
 			Bones.push_back(b);
@@ -333,7 +333,7 @@ Poly::MeshResource::Animation::Animation(aiAnimation * anim)
 			c.Scales.push_back({ vector, (float)anim->mChannels[i]->mScalingKeys[j].mTime });
 		}
 		core::storage::String nameCpy = c.Name;
-		channels.emplace(std::make_pair( nameCpy, std::move(c) ));
+		channels.emplace( nameCpy, std::move(c) );
 	}
 }
 


### PR DESCRIPTION
insert creates a temporary copy of the object, while emplace forward passed arguments, minor optimization tweak.